### PR TITLE
update: clarity 01

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ If you're looking to use this website as a base for your own Jekyll site you can
 ## Deployments
 - All commits to `master` will go live
 - Netlify provides preview branches and is responsible for hosting
+
+## Clarity Testing
+- 01


### PR DESCRIPTION
# RRICH.io
---
rrich.io - replaces [github.com/rr1000/ryansrich.com/tree/master](https://github.com/rr1000/ryansrich.com/)

## How to use this site
If you're looking to use this website as a base for your own Jekyll site you can do so. This software is free and open for anyone to use.

## Local Setup
- [Follow instructions for environment setup on Jekyll's website](https://jekyllrb.com/docs/)
- `bundle exec jekyll serve`

## Deployments
- All commits to `master` will go live
- Netlify provides preview branches and is responsible for hosting